### PR TITLE
Remove 'erasableSyntaxOnly' option from tsconfig

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Clean up TypeScript configuration by dropping the `erasableSyntaxOnly` option from tsconfig.app.json.