### PR TITLE
Remove 'erasableSyntaxOnly' from tsconfig

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,7 +18,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplify TypeScript configuration by dropping the `erasableSyntaxOnly` compiler option from the Node-specific tsconfig.